### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,10 @@ nametrans
 .. image:: https://travis-ci.org/numerodix/nametrans.png?branch=master
     :target: https://travis-ci.org/numerodix/nametrans
 
-.. image:: https://pypip.in/wheel/nametrans/badge.png
+.. image:: https://img.shields.io/pypi/wheel/nametrans.svg
     :target: https://pypi.python.org/pypi/nametrans/
 
-.. image:: https://pypip.in/license/nametrans/badge.png
+.. image:: https://img.shields.io/pypi/l/nametrans.svg
         :target: https://pypi.python.org/pypi/nametrans/
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nametrans))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nametrans`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.